### PR TITLE
Nodejs crashes sometimes with error below

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,9 +29,13 @@ let serveUi5 = function(oSettings, app) {
       agent: oAgent
     });
     const $ = cheerio.load(await flp.text());
-    $("#sap-ui-bootstrap").attr().src = cdn + "/resources/sap-ui-core.js";
-    $("#sap-ushell-bootstrap").attr().src =
-      cdn + "/test-resources/sap/ushell/bootstrap/sandbox.js";
+    if ($("#sap-ui-bootstrap").attr()) {
+      $("#sap-ui-bootstrap").attr().src = cdn + "/resources/sap-ui-core.js";
+    }
+    if ($("#sap-ushell-bootstrap").attr()) {
+      $("#sap-ushell-bootstrap").attr().src =
+        cdn + "/test-resources/sap/ushell/bootstrap/sandbox.js";
+    }
 
     res.send($.html());
   });


### PR DESCRIPTION
(node:15232) UnhandledPromiseRejectionWarning: TypeError: Cannot set property 'src' of undefined
    at app.get (C:\Users\demu\fio\node_modules\express-sapui5\index.js:32:39)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
(node:15232) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:15232) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.